### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Implemented a basic Express server with a search endpoint for tasks.

### What changed?

- Created a new `server.js` file in the `graphite-demo` directory.
- Set up an Express server listening on port 3000.
- Defined a sample array of tasks with id and description.
- Implemented a GET `/search` endpoint that:
  - Accepts a query parameter for searching tasks.
  - Filters tasks based on the search query.
  - Sorts the filtered tasks alphabetically by description.
  - Returns the sorted tasks as a JSON response.

### How to test?

1. Start the server by running `node server.js`.
2. Use a tool like cURL or Postman to send GET requests to `http://localhost:3000/search`.
3. Test with different query parameters, e.g.:
   - `http://localhost:3000/search?query=report`
   - `http://localhost:3000/search?query=team`
   - `http://localhost:3000/search` (no query parameter)
4. Verify that the response contains filtered and sorted tasks based on the search query.

### Why make this change?

This change provides a foundation for a task management API, allowing users to search and retrieve tasks based on their descriptions. It demonstrates basic Express server setup, request handling, and data manipulation, which can be expanded upon for more complex functionality in the future.